### PR TITLE
Fix Vocab Tennis asset paths

### DIFF
--- a/Class Tools/Vocab Tennis/vocab-tennis.html
+++ b/Class Tools/Vocab Tennis/vocab-tennis.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Vocab Tennis</title>
-<link rel="stylesheet" href="css/vocab-tennis.css">
+<link rel="stylesheet" href="vocab-tennis.css">
 </head>
 <body>
 <div id="orbRain"></div>
@@ -66,6 +66,6 @@
   <button id="exportWords">Export Words</button>
 </div>
 
-<script src="js/vocab-tennis.js"></script>
+<script src="vocab-tennis.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Correct HTML links to local CSS and JavaScript after directory reorganization

## Testing
- `cd 'Class Tools/Vocab Tennis' && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a8e119aeb083308ab73e9f1485d837